### PR TITLE
Add Advanced Tips section + Save/Restore party + structured messages

### DIFF
--- a/advanced-tips/gather-knowledge.yaml
+++ b/advanced-tips/gather-knowledge.yaml
@@ -1,0 +1,37 @@
+title: Gather Knowledge
+description: Checks that someone in the party has strong Diplomacy or Society for Recall Knowledge and Gather Information
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const abilityModifier = (score) => Math.floor((Number(score || 10) - 10) / 2);
+    const maxLevel = Math.max(...characters.map(c => c.build?.level || 0));
+
+    const computeSkillBonus = (c, skill, abil) => {
+      const profValue = Number(c.build?.proficiencies?.[skill] || 0);
+      const level = c.build?.level || 0;
+      const mod = abilityModifier(c.build?.abilities?.[abil]);
+      return (profValue > 0 ? level : 0) + profValue + mod;
+    };
+
+    let bestDip = -Infinity, bestDipName = 'nobody';
+    let bestSoc = -Infinity, bestSocName = 'nobody';
+    for (const c of characters) {
+      const dip = computeSkillBonus(c, 'diplomacy', 'cha');
+      if (dip > bestDip) { bestDip = dip; bestDipName = c.build?.name || 'Unknown'; }
+      const soc = computeSkillBonus(c, 'society', 'int');
+      if (soc > bestSoc) { bestSoc = soc; bestSocName = c.build?.name || 'Unknown'; }
+    }
+
+    // Hard DC for highest-party-level Recall Knowledge ≈ level + 15. Trained-floor target ≈ level + 4.
+    const target = maxLevel + 4;
+    const fmt = (v) => (v >= 0 ? `+${v}` : `${v}`);
+
+    window.gatherBestDip = `${fmt(bestDip)} (${bestDipName})`;
+    window.gatherBestSoc = `${fmt(bestSoc)} (${bestSocName})`;
+    window.gatherTarget = `+${target}`;
+
+    return bestDip >= target || bestSoc >= target;
+  }
+successMessage: "Your party has a strong Recall Knowledge / Gather Information bench. Best Diplomacy: {{gatherBestDip}}. Best Society: {{gatherBestSoc}}. Target for hard checks at your level: {{gatherTarget}}."
+failureMessage: "Recall Knowledge and Gather Information depend mostly on Diplomacy or Society. Best Diplomacy: {{gatherBestDip}}. Best Society: {{gatherBestSoc}}. Target for hard checks at your level: {{gatherTarget}}. Either invest in proficiency or boost Cha/Int on the party face so you can succeed against hard DCs."

--- a/advanced-tips/reaction-time.yaml
+++ b/advanced-tips/reaction-time.yaml
@@ -1,0 +1,39 @@
+title: Reaction Time
+description: Checks that every character has at least one reaction ability for combat depth
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const reactionFeats = [
+      'Reactive Strike',
+      'Attack of Opportunity',
+      'Stand Still',
+      'No Escape',
+      "You're Next",
+      'Shield Block',
+      'Nimble Dodge',
+      'Reactive Shield',
+      'Cover-Up'
+    ];
+
+    const withReactions = [];
+    const without = [];
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+      const feats = c.build?.feats || [];
+
+      const matched = feats
+        .map(f => Array.isArray(f) ? f[0] : f)
+        .filter(featName => reactionFeats.includes(featName));
+
+      if (matched.length > 0) withReactions.push(`${name} (${matched.join(', ')})`);
+      else without.push(name);
+    }
+
+    window.reactionEquipped = withReactions.length ? withReactions.join('; ') : 'nobody';
+    window.reactionMissing = without;
+    return without.length === 0;
+  }
+successMessage: "Every character has a reaction ability, so the party can punish enemy movement, block hits, and dodge attacks. Equipped: {{reactionEquipped}}."
+failureMessage: "Reactions are how characters interact with enemy turns — stopping movement (Reactive Strike, Stand Still), absorbing hits (Shield Block, Nimble Dodge), or chaining attacks (You're Next). Without one, a character is a passive bystander on enemy turns. No reaction ability: {{reactionMissing.join(', ')}}. Already equipped: {{reactionEquipped}}."

--- a/advanced-tips/rock-paper-scissors.yaml
+++ b/advanced-tips/rock-paper-scissors.yaml
@@ -1,0 +1,50 @@
+title: Rock, Paper, Scissors
+description: Coverage of bludgeoning, slashing, and piercing physical damage
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const targets = {
+      bludgeoning: { label: 'Bludgeoning', why: 'skeletons resist piercing/slashing — and many oozes too' },
+      slashing:    { label: 'Slashing',    why: 'best against plants and many beasts' },
+      piercing:    { label: 'Piercing',    why: 'best at ranged and against some armored foes' }
+    };
+
+    const weaponDamage = (name) => {
+      const n = String(name || '').toLowerCase();
+      const types = new Set();
+      if (/(mace|club|hammer|sap|staff|maul|morningstar|warhammer|flail|sling)/.test(n)) types.add('bludgeoning');
+      if (/(sword|scimitar|falchion|axe|sickle|kukri|machete|katar)/.test(n)) types.add('slashing');
+      if (/(dagger|spear|pick|rapier|stiletto|bow|crossbow|dart|javelin|lance|arrow)/.test(n)) types.add('piercing');
+      return types;
+    };
+
+    const carriers = { bludgeoning: new Set(), slashing: new Set(), piercing: new Set() };
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+      for (const w of (c.build?.weapons || [])) {
+        const wname = (Array.isArray(w) ? w[0] : (w?.name || w?.display || w)) || '';
+        const declared = (w?.damageType || w?.damage_type || w?.dmgType || '').toLowerCase();
+        if (declared && targets[declared]) {
+          carriers[declared].add(`${name} (${wname})`);
+          continue;
+        }
+        for (const t of weaponDamage(wname)) carriers[t].add(`${name} (${wname})`);
+      }
+    }
+
+    const coveredLines = [];
+    const gaps = [];
+    for (const key of Object.keys(targets)) {
+      const list = Array.from(carriers[key]);
+      if (list.length > 0) coveredLines.push(`${targets[key].label} via ${list.join(', ')}`);
+      else gaps.push(`${targets[key].label} — ${targets[key].why}`);
+    }
+
+    window.rpsCovered = coveredLines.length ? coveredLines.join('; ') : 'nothing';
+    window.rpsGaps = gaps;
+    return gaps.length === 0;
+  }
+successMessage: "Your party can deal all three physical damage types — bludgeoning, slashing, and piercing — so you can swap weapons to bypass enemy resistances. Currently covered: {{rpsCovered}}."
+failureMessage: "Enemies frequently resist one physical damage type. Missing: {{rpsGaps.join(' | ')}}. Already covered: {{rpsCovered}}. Have someone keep a backup weapon in the missing type."

--- a/advanced-tips/see-no-evil.yaml
+++ b/advanced-tips/see-no-evil.yaml
@@ -1,0 +1,38 @@
+title: See No Evil
+description: Checks party access to invisibility for scouting, escapes, and ambushes
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+    const avgLevel = characters.reduce((a, c) => a + (c.build?.level || 0), 0) / characters.length;
+    if (avgLevel < 3 || avgLevel > 20) return true;
+
+    const itemHints = ['invisibility', 'vanish', 'mantle of the unwavering', 'invisibility potion', 'dust of disappearance'];
+    const carriers = new Set();
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+
+      for (const item of [...(c.build?.equipment || []), ...(c.build?.weapons || [])]) {
+        const itemName = String((Array.isArray(item) ? item[0] : (item?.name || item?.display || item)) || '').toLowerCase();
+        if (itemHints.some(h => itemName.includes(h))) carriers.add(`${name} (${itemName.trim()})`);
+      }
+
+      const spellsSeen = new Set();
+      for (const caster of (c.build?.spellCasters || [])) {
+        for (const lg of [caster.prepared, caster.spells].filter(Boolean)) {
+          for (const ld of lg) (ld.list || []).forEach(s => spellsSeen.add(s));
+        }
+      }
+      for (const lvl in (c.build?.spellsKnown || {})) (c.build.spellsKnown[lvl] || []).forEach(s => spellsSeen.add(s));
+
+      for (const s of spellsSeen) {
+        const lower = (s || '').toLowerCase();
+        if (lower.includes('invisibility') || lower === 'vanish') carriers.add(`${name} (${s})`);
+      }
+    }
+
+    window.invisCarriers = carriers.size > 0 ? Array.from(carriers).join(', ') : 'nobody';
+    return carriers.size > 0;
+  }
+successMessage: "Someone in the party can turn invisible for scouting, ambushes, or quick escapes. Available via {{invisCarriers}}."
+failureMessage: "Invisibility solves a huge range of problems — scouting ahead, breaking line of sight to escape, setting up ambushes, and surviving deadly fights. No one in your party currently has access. Consider Invisibility (4th-rank), Vanish (2nd-rank), or an Invisibility Potion in someone's inventory."

--- a/advanced-tips/shadow-plane-sucks.yaml
+++ b/advanced-tips/shadow-plane-sucks.yaml
@@ -1,0 +1,34 @@
+title: The Shadow Plane Sucks
+description: Checks that high-level casters carry a Shadow Signet for shifting attack-spell targeting
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const eligible = characters.filter(c => {
+      const level = c.build?.level || 0;
+      const isCaster = Boolean(c.build?.spellCasters && c.build.spellCasters.length > 0);
+      return isCaster && level >= 10 && level <= 20;
+    });
+
+    if (eligible.length === 0) return true;
+
+    const equipped = [];
+    const missing = [];
+
+    for (const caster of eligible) {
+      const name = caster.build?.name || 'Unknown';
+      const equipment = caster.build?.equipment || [];
+      const has = equipment.some(item => {
+        const itemName = (Array.isArray(item) ? item[0] : (item?.name || item)) || '';
+        return typeof itemName === 'string' && itemName.toLowerCase().includes('shadow signet');
+      });
+      if (has) equipped.push(name);
+      else missing.push(name);
+    }
+
+    window.signetEquipped = equipped.length ? equipped.join(', ') : 'no casters';
+    window.signetMissing = missing;
+    return missing.length === 0;
+  }
+successMessage: "All high-level casters in the party carry a Shadow Signet, letting them retarget attack-roll spells against AC instead of saves — clutch against incorporeal foes and high-save enemies. Equipped: {{signetEquipped}}."
+failureMessage: "Shadow Signet (level 10 item) lets a caster switch an attack-spell from a save to a touch AC attack — especially valuable against incorporeal creatures and enemies with sky-high saves. Casters without one: {{signetMissing.join(', ')}}. Already equipped: {{signetEquipped}}."

--- a/advanced-tips/spiritual-pressure.yaml
+++ b/advanced-tips/spiritual-pressure.yaml
@@ -1,0 +1,83 @@
+title: Spiritual Pressure
+description: Coverage of Vitality, Void, and Spirit damage plus Holy/Unholy source traits
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const spellHints = {
+      vitality: { label: 'Vitality damage', why: 'destroys undead', patterns: [
+        /\bvitality\b/i, /\bheal\b/i, /vital beacon/i, /sunburst/i, /searing light/i,
+        /breath of life/i, /lay on hands/i, /sun blade/i, /daylight/i, /life pact/i
+      ]},
+      void: { label: 'Void damage', why: 'drains the living', patterns: [
+        /\bvoid\b/i, /\bharm\b/i, /vampiric/i, /grim tendrils/i, /bind undead/i,
+        /wail of the banshee/i, /drain life/i, /death knell/i, /ravenous darkness|ravening maw/i,
+        /crushing despair/i, /soul siphon/i
+      ]},
+      spirit: { label: 'Spirit damage', why: 'hits incorporeal creatures and possessing spirits (ignores constructs)', patterns: [
+        /\bspirit\b/i, /phantom pain/i, /spiritual armament/i, /spiritual anamnesis/i,
+        /spectral hand/i, /banishment/i, /\bsmite\b/i, /spirit blast/i
+      ]},
+      holy: { label: 'Holy trait', why: 'sources tagged Holy deal extra damage to Unholy creatures (fiends, evil champions)', patterns: [
+        /\bholy\b/i, /sanctification/i, /litany against wrath/i, /champion's sacrifice/i
+      ]},
+      unholy: { label: 'Unholy trait', why: 'sources tagged Unholy deal extra damage to Holy creatures (celestials, good champions)', patterns: [
+        /\bunholy\b/i, /unholy cascade/i, /devotion to (evil|the wicked)/i
+      ]}
+    };
+
+    const partyHits = {};
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+
+      const text = [];
+      for (const caster of (c.build?.spellCasters || [])) {
+        for (const lg of [caster.prepared, caster.spells].filter(Boolean)) {
+          for (const ld of lg) text.push(...(ld.list || []));
+        }
+      }
+      for (const lvl in (c.build?.spellsKnown || {})) text.push(...(c.build.spellsKnown[lvl] || []));
+      try { text.push(JSON.stringify(c.build?.focus || {})); } catch (_) {}
+      for (const w of (c.build?.weapons || [])) {
+        const wname = (Array.isArray(w) ? w[0] : (w?.name || w?.display || w)) || '';
+        text.push(String(wname));
+        if (w && typeof w === 'object') {
+          for (const slot of [w.runes, w.prop1, w.prop2, w.prop3, w.prop4, w.runeList].filter(Boolean)) {
+            text.push(Array.isArray(slot) ? slot.join(' ') : String(slot));
+          }
+        }
+      }
+      for (const item of (c.build?.equipment || [])) {
+        text.push(String((Array.isArray(item) ? item[0] : (item?.name || item?.display || item)) || ''));
+      }
+      if (c.build?.sanctification) text.push(String(c.build.sanctification));
+      if (c.build?.deity) text.push(String(c.build.deity));
+
+      const joined = text.join(' | ');
+      for (const [key, def] of Object.entries(spellHints)) {
+        if (def.patterns.some(p => p.test(joined))) {
+          (partyHits[key] = partyHits[key] || new Set()).add(name);
+        }
+      }
+    }
+
+    const order = ['vitality', 'void', 'spirit', 'holy', 'unholy'];
+    const coveredLines = [];
+    const gaps = [];
+    for (const key of order) {
+      const def = spellHints[key];
+      const names = partyHits[key];
+      if (names && names.size > 0) {
+        coveredLines.push(`${def.label} via ${Array.from(names).join(', ')}`);
+      } else {
+        gaps.push(`${def.label} — ${def.why}`);
+      }
+    }
+
+    window.spiritualPressureCovered = coveredLines.length ? coveredLines.join('; ') : 'nothing';
+    window.spiritualPressureGaps = gaps;
+    return gaps.length === 0;
+  }
+successMessage: "Your party covers the Remaster divine-adjacent damage spectrum — Vitality (anti-undead), Void (anti-living), Spirit (anti-incorporeal), and both Holy and Unholy source traits. Covered: {{spiritualPressureCovered}}."
+failureMessage: "Celestials, fiends, and undead often need specific damage types. Missing: {{spiritualPressureGaps.join(' | ')}}. Already covered: {{spiritualPressureCovered}}. Add the missing spells (Heal/Harm/Phantom Pain/etc.) or holy/unholy weapon runes."

--- a/advanced-tips/started-blasting.yaml
+++ b/advanced-tips/started-blasting.yaml
@@ -1,0 +1,66 @@
+title: Anyway, I Started Blasting
+description: Coverage of fire, electricity, cold, acid, poison, sonic, and force damage
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const energyTypes = {
+      fire:       { label: 'Fire',        why: 'staple energy type; many cold-themed creatures are weak to it' },
+      electric:   { label: 'Electricity', why: 'great against water creatures and metal-armored foes' },
+      cold:       { label: 'Cold',        why: 'staple against fire creatures and many fiends' },
+      acid:       { label: 'Acid',        why: 'few creatures resist acid; persistent damage helps in long fights' },
+      poison:     { label: 'Poison',      why: 'good against living creatures, but immune undead/constructs' },
+      sonic:      { label: 'Sonic',       why: 'rarely resisted, common weakness for crystalline and statue-like foes' },
+      force:      { label: 'Force',       why: 'bypasses incorporeal resistance; reliable against ghosts' }
+    };
+
+    const patterns = {
+      fire:     [/fire/i, /flame/i, /burn/i, /fireball/i, /scorching/i, /produce flame/i, /flaming/i, /searing/i, /sun blade/i],
+      electric: [/electric/i, /lightning/i, /thunderstrike/i, /shocking/i, /\bshock\b/i, /storm/i],
+      cold:     [/cold/i, /frost/i, /\bice\b/i, /chill/i, /freezing/i, /winter/i, /frostbite/i, /cone of cold/i],
+      acid:     [/acid/i, /caustic/i, /corrosive/i, /grasping vine/i],
+      poison:   [/poison/i, /venom/i, /toxic/i, /noxious/i],
+      sonic:    [/sonic/i, /\bsound\b/i, /shatter/i, /screaming/i, /thunderstrike/i],
+      force:    [/force/i, /magic missile/i, /force barrage/i, /telekinetic/i]
+    };
+
+    const carriers = {};
+    Object.keys(patterns).forEach(k => carriers[k] = new Set());
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+      const spells = new Set();
+      for (const caster of (c.build?.spellCasters || [])) {
+        for (const lg of [caster.prepared, caster.spells].filter(Boolean)) {
+          for (const ld of lg) (ld.list || []).forEach(s => spells.add(s));
+        }
+      }
+      for (const lvl in (c.build?.spellsKnown || {})) (c.build.spellsKnown[lvl] || []).forEach(s => spells.add(s));
+
+      const items = new Set();
+      for (const w of (c.build?.weapons || [])) items.add(String((Array.isArray(w) ? w[0] : (w?.name || w?.display || w)) || ''));
+      for (const item of (c.build?.equipment || [])) items.add(String((Array.isArray(item) ? item[0] : (item?.name || item?.display || item)) || ''));
+
+      const focusBlob = (() => { try { return JSON.stringify(c.build?.focus || {}); } catch { return ''; } })();
+
+      const allText = [...spells, ...items, focusBlob].join(' | ');
+
+      for (const [type, pats] of Object.entries(patterns)) {
+        if (pats.some(p => p.test(allText))) carriers[type].add(name);
+      }
+    }
+
+    const coveredLines = [];
+    const gaps = [];
+    for (const key of Object.keys(energyTypes)) {
+      const names = Array.from(carriers[key]);
+      if (names.length > 0) coveredLines.push(`${energyTypes[key].label} via ${names.join(', ')}`);
+      else gaps.push(`${energyTypes[key].label} — ${energyTypes[key].why}`);
+    }
+
+    window.blastingCovered = coveredLines.length ? coveredLines.join('; ') : 'nothing';
+    window.blastingGaps = gaps;
+    return gaps.length === 0;
+  }
+successMessage: "Your party covers the full energy damage spectrum, so you can punch through enemy resistances by swapping spells. Covered: {{blastingCovered}}."
+failureMessage: "Some monsters are functionally invulnerable to the damage your party deals. Missing: {{blastingGaps.join(' | ')}}. Already covered: {{blastingCovered}}. Pick up a spell or item in the missing type to round out your blasting options."

--- a/advanced-tips/stitch-flesh.yaml
+++ b/advanced-tips/stitch-flesh.yaml
@@ -1,0 +1,27 @@
+title: Stitch Flesh
+description: If the party has an undead character, checks for Stitch Flesh so medics can heal them
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const undeadHints = ['undead', 'skeleton', 'zombie', 'ghoul', 'vampire', 'lich', 'mummy', 'wight'];
+
+    const undeadMembers = characters.filter(c => {
+      const ancestry = (c.build?.ancestry || '').toLowerCase();
+      const heritage = (c.build?.heritage || '').toLowerCase();
+      return undeadHints.some(t => ancestry.includes(t) || heritage.includes(t));
+    }).map(c => c.build?.name || 'Unknown');
+
+    if (undeadMembers.length === 0) return true;
+
+    const stitchers = characters.filter(c => {
+      const feats = c.build?.feats || [];
+      return feats.some(f => (Array.isArray(f) ? f[0] : f) === 'Stitch Flesh');
+    }).map(c => c.build?.name || 'Unknown');
+
+    window.undeadMembers = undeadMembers.join(', ');
+    window.stitchers = stitchers.length ? stitchers.join(', ') : 'nobody';
+    return stitchers.length > 0;
+  }
+successMessage: "Your party has an undead member ({{undeadMembers}}) and someone with Stitch Flesh ({{stitchers}}) — Treat Wounds and similar vitality healing will work on them."
+failureMessage: "Undead characters take damage from normal vitality-based healing (Treat Wounds, Heal). With an undead member ({{undeadMembers}}) in the party and nobody trained in Stitch Flesh, your medics can't patch them up in the field. One character with Medicine proficiency should pick up Stitch Flesh."

--- a/advanced-tips/swing-and-a-miss.yaml
+++ b/advanced-tips/swing-and-a-miss.yaml
@@ -1,0 +1,54 @@
+title: Swing and a Miss!
+description: Checks party tools for damaging incorporeal creatures (ghosts, shades, possessing spirits)
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const avgLevel = characters.reduce((a, c) => a + (c.build?.level || 0), 0) / characters.length;
+    if (avgLevel < 5) return true;
+
+    const forceSpellPatterns = [/force barrage/i, /magic missile/i, /spiritual armament/i, /phantom pain/i, /phantasmal calamity/i, /falling stars/i];
+    const spiritPatterns = [/\bspirit\b/i, /vitality/i, /\bvoid\b/i, /banishment/i];
+    const runePatterns = [/ghost touch/i, /spirit-?bond/i, /\bholy\b/i, /\bunholy\b/i];
+
+    const carriers = new Set();
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+
+      // Weapon runes
+      for (const w of (c.build?.weapons || [])) {
+        const wname = String((Array.isArray(w) ? w[0] : (w?.name || w?.display || w)) || '');
+        if (runePatterns.some(p => p.test(wname))) carriers.add(`${name} (${wname})`);
+        if (w && typeof w === 'object') {
+          const runes = [w.runes, w.prop1, w.prop2, w.prop3, w.prop4, w.runeList].filter(Boolean);
+          const runeText = runes.map(r => Array.isArray(r) ? r.join(' ') : String(r)).join(' ');
+          if (runePatterns.some(p => p.test(runeText))) carriers.add(`${name} (${wname || 'weapon'} w/ ${runeText.trim()})`);
+        }
+      }
+      for (const item of (c.build?.equipment || [])) {
+        const itemName = String((Array.isArray(item) ? item[0] : (item?.name || item?.display || item)) || '');
+        if (runePatterns.some(p => p.test(itemName))) carriers.add(`${name} (${itemName})`);
+      }
+
+      // Spells
+      const spellsSeen = new Set();
+      for (const caster of (c.build?.spellCasters || [])) {
+        for (const lg of [caster.prepared, caster.spells].filter(Boolean)) {
+          for (const ld of lg) (ld.list || []).forEach(s => spellsSeen.add(s));
+        }
+      }
+      for (const lvl in (c.build?.spellsKnown || {})) (c.build.spellsKnown[lvl] || []).forEach(s => spellsSeen.add(s));
+
+      for (const s of spellsSeen) {
+        const lower = (s || '').toLowerCase();
+        if (forceSpellPatterns.some(p => p.test(lower))) carriers.add(`${name} (${s})`);
+        else if (spiritPatterns.some(p => p.test(lower))) carriers.add(`${name} (${s})`);
+      }
+    }
+
+    window.incorporealCarriers = carriers.size ? Array.from(carriers).join(', ') : 'nobody';
+    return carriers.size > 0;
+  }
+successMessage: "Your party can reliably damage incorporeal creatures (ghosts, shades, possessing spirits). Force damage, spirit damage, vitality/void spells, and ghost-touch/holy/unholy runes all work. Available via {{incorporealCarriers}}."
+failureMessage: "Incorporeal creatures (ghosts, shades, banshees) take half damage from anything that isn't Force damage, spirit damage, or a weapon with ghost touch / holy / unholy / spirit-bond runes. With nobody in the party able to reliably hurt them, fights against incorporeal foes will grind. Pick up Force Barrage, Magic Missile, Spiritual Armament, or a ghost-touch rune on a martial's weapon."

--- a/advanced-tips/too-poor.yaml
+++ b/advanced-tips/too-poor.yaml
@@ -1,0 +1,69 @@
+title: Awh, Too Poor?
+description: Checks party access to silver, cold iron, and adamantine for bypassing creature weaknesses
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const avgLevel = characters.reduce((a, c) => a + (c.build?.level || 0), 0) / characters.length;
+    if (avgLevel < 1 || avgLevel > 20) return true;
+
+    const materials = [
+      { key: 'silver',     label: 'Silver',     minLevel: 1, why: 'werewolves and other lycanthropes resist non-silver weapons' },
+      { key: 'cold iron',  label: 'Cold Iron',  minLevel: 1, why: 'fey, redcaps, and demons resist non-cold-iron weapons' },
+      { key: 'adamantine', label: 'Adamantine', minLevel: 8, why: 'golems, constructs, and hardness-heavy enemies require adamantine to bypass' }
+    ];
+    const adamantineAliases = /adamantine|adamantium/i;
+    const carriers = { silver: new Set(), 'cold iron': new Set(), adamantine: new Set() };
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+      const sources = [
+        ...(c.build?.weapons || []),
+        ...(c.build?.equipment || [])
+      ];
+
+      for (const item of sources) {
+        const itemName = String((Array.isArray(item) ? item[0] : (item?.name || item?.display || item)) || '');
+        const lower = itemName.toLowerCase();
+        if (lower.includes('silver')) carriers.silver.add(`${name} (${itemName})`);
+        if (lower.includes('cold iron')) carriers['cold iron'].add(`${name} (${itemName})`);
+        if (adamantineAliases.test(itemName)) carriers.adamantine.add(`${name} (${itemName})`);
+      }
+
+      // Needle Darts: caster can produce silver damage natively (cast with silver coins as ammo)
+      let hasNeedleDarts = false;
+      for (const caster of (c.build?.spellCasters || [])) {
+        const groups = [caster.prepared, caster.spells].filter(Boolean);
+        for (const levelGroup of groups) {
+          for (const levelData of levelGroup) {
+            if ((levelData.list || []).some(s => /needle darts/i.test(s || ''))) hasNeedleDarts = true;
+          }
+        }
+      }
+      const known = c.build?.spellsKnown || {};
+      for (const lvl in known) {
+        if ((known[lvl] || []).some(s => /needle darts/i.test(s || ''))) hasNeedleDarts = true;
+      }
+      if (hasNeedleDarts) carriers.silver.add(`${name} (Needle Darts cast with silver coins)`);
+    }
+
+    const coveredLines = [];
+    const gaps = [];
+
+    for (const m of materials) {
+      const list = Array.from(carriers[m.key]);
+      const gated = avgLevel < m.minLevel;
+      if (list.length > 0) {
+        coveredLines.push(`${m.label} covered by ${list.join(', ')}`);
+      } else if (!gated) {
+        gaps.push(`${m.label} — ${m.why}`);
+      }
+    }
+
+    window.tooPoorCovered = coveredLines.length ? coveredLines.join('; ') : 'nothing';
+    window.tooPoorGaps = gaps;
+
+    return gaps.length === 0;
+  }
+successMessage: "Your party can bypass the common material-based resistances of werewolves (silver), fey (cold iron), and golems/constructs (adamantine, once level 8+). Currently covered: {{tooPoorCovered}}."
+failureMessage: "Some monsters resist anything but specific weapon materials. Missing coverage: {{tooPoorGaps.join(' | ')}}. Already covered: {{tooPoorCovered}}. Pick up a weapon in the missing material, or cast Needle Darts with the appropriate metal coins as ammunition."

--- a/advanced-tips/trained-no-mod.yaml
+++ b/advanced-tips/trained-no-mod.yaml
@@ -1,0 +1,37 @@
+title: Trained but Mid
+description: Flags skills that are trained on a dump stat (ability modifier ≤ 0)
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const abilityModifier = (score) => Math.floor((Number(score || 10) - 10) / 2);
+    const skillAbility = {
+      acrobatics: 'dex', arcana: 'int', athletics: 'str', crafting: 'int',
+      deception: 'cha', diplomacy: 'cha', intimidation: 'cha', medicine: 'wis',
+      nature: 'wis', occultism: 'int', performance: 'cha', religion: 'wis',
+      society: 'int', stealth: 'dex', survival: 'wis', thievery: 'dex'
+    };
+
+    const offenders = [];
+
+    for (const c of characters) {
+      const name = c.build?.name || 'Unknown';
+      const profs = c.build?.proficiencies || {};
+      const abilities = c.build?.abilities || {};
+
+      for (const [skill, abil] of Object.entries(skillAbility)) {
+        const profValue = Number(profs[skill] || 0);
+        if (profValue <= 0) continue;
+        const mod = abilityModifier(abilities[abil]);
+        if (mod <= 0) {
+          const sign = mod >= 0 ? '+' : '';
+          offenders.push(`${name}: ${skill[0].toUpperCase() + skill.slice(1)} (${abil.toUpperCase()} ${sign}${mod})`);
+        }
+      }
+    }
+
+    window.trainedNoModList = offenders;
+    return offenders.length === 0;
+  }
+successMessage: "Every trained skill in your party is backed by an ability score of at least 12, so the training is actually adding to the bonus. No wasted skill investments."
+failureMessage: "Training a skill on a dump-stat ability means the bonus barely moves above untrained — the level + proficiency stacks, but the ability modifier drags it down. Trained-on-a-dump-stat: {{trainedNoModList.join(' | ')}}. Consider retraining the skill or boosting the underlying ability score."

--- a/advanced-tips/training-arc.yaml
+++ b/advanced-tips/training-arc.yaml
@@ -1,0 +1,72 @@
+title: Training Arc
+description: Checks that martial characters have level-appropriate magic weapons
+checkFunction: |
+  function() {
+    if (characters.length === 0) return true;
+
+    const martialClasses = new Set([
+      'Fighter', 'Champion', 'Barbarian', 'Ranger', 'Rogue', 'Monk',
+      'Magus', 'Gunslinger', 'Inventor', 'Investigator', 'Swashbuckler',
+      'Thaumaturge', 'Kineticist'
+    ]);
+
+    const tiers = [
+      { min: 2, max: 3, need: '+1 weapon',                       match: /\+1(?!\s*striking)/i },
+      { min: 4, max: 9, need: '+1 striking weapon',              match: /\+1\s*striking|striking/i },
+      { min: 10, max: 11, need: '+2 striking weapon',            match: /\+2\s*striking/i },
+      { min: 12, max: 15, need: '+2 greater striking weapon',    match: /\+2\s*greater\s*striking/i },
+      { min: 16, max: 18, need: '+3 greater striking weapon',    match: /\+3\s*greater\s*striking/i },
+      { min: 19, max: 20, need: '+3 major striking weapon',      match: /\+3\s*major\s*striking/i }
+    ];
+
+    const equipped = [];
+    const underArmed = [];
+
+    for (const c of characters) {
+      const level = c.build?.level || 0;
+      const cls = c.build?.class || '';
+      const name = c.build?.name || 'Unknown';
+      if (!martialClasses.has(cls)) continue;
+
+      const tier = tiers.find(t => level >= t.min && level <= t.max);
+      if (!tier) continue;
+
+      const weapons = c.build?.weapons || [];
+      const equipment = c.build?.equipment || [];
+      const sources = [...weapons, ...equipment];
+
+      let bestWeapon = null;
+      const hasMatch = sources.some(item => {
+        const itemName = (Array.isArray(item) ? item[0] : (item?.name || item?.display || item)) || '';
+        if (tier.match.test(String(itemName))) { bestWeapon = itemName; return true; }
+        return false;
+      });
+
+      const hasRune = !hasMatch && weapons.some(w => {
+        if (!w || typeof w !== 'object') return false;
+        const pot = Number(w.pot ?? w.potency ?? 0);
+        const striking = String(w.str ?? w.striking ?? '').toLowerCase();
+        let ok = false;
+        if (level >= 2 && level <= 3) ok = pot >= 1;
+        else if (level >= 4 && level <= 9) ok = pot >= 1 && Boolean(striking);
+        else if (level >= 10 && level <= 11) ok = pot >= 2 && Boolean(striking);
+        else if (level >= 12 && level <= 15) ok = pot >= 2 && /greater/.test(striking);
+        else if (level >= 16 && level <= 18) ok = pot >= 3 && /greater/.test(striking);
+        else if (level >= 19 && level <= 20) ok = pot >= 3 && /major/.test(striking);
+        if (ok) bestWeapon = String(w.name || w.display || `+${pot} ${striking}`).trim();
+        return ok;
+      });
+
+      if (hasMatch || hasRune) {
+        equipped.push(`${name} (lv ${level}, ${bestWeapon})`);
+      } else {
+        underArmed.push(`${name} (lv ${level}, needs ${tier.need})`);
+      }
+    }
+
+    window.trainingArcEquipped = equipped.length ? equipped.join(', ') : 'nobody';
+    window.trainingArcUnderArmed = underArmed;
+    return underArmed.length === 0;
+  }
+successMessage: "Every martial in the party has a magic weapon matching their level — they keep up with the attack bonus and damage dice the game expects. Equipped: {{trainingArcEquipped}}."
+failureMessage: "PF2e enemies are tuned assuming martials have level-appropriate magic weapons. Without them, you miss more often and deal one die less. Under-equipped: {{trainingArcUnderArmed.join(' | ')}}. Already equipped: {{trainingArcEquipped}}."

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
             <div class="import-section">
                 <div class="import-controls">
-                    <label for="jsonFileInput" class="file-input-label">
+                    <label for="jsonFileInput" class="pf-button">
                         <i class="fas fa-file-import"></i> Select File
                         <input type="file" id="jsonFileInput" accept=".json,.txt">
                     </label>
@@ -47,6 +47,12 @@
                             class="fas fa-share-nodes"></i> Share Party</button>
                     <button id="importPartyClipboardButton" class="pf-button secondary"><i
                             class="fas fa-people-group"></i> Import Party</button>
+                    <button id="savePartyFileButton" class="pf-button secondary"><i
+                            class="fas fa-floppy-disk"></i> Save Party to File</button>
+                    <label for="restorePartyFileInput" class="pf-button secondary">
+                        <i class="fas fa-folder-open"></i> Restore Party from File
+                        <input type="file" id="restorePartyFileInput" accept=".json,.txt">
+                    </label>
                 </div>
             </div>
 
@@ -68,6 +74,14 @@
             <div id="tenuousTipsContainer" class="warnings-container">
                 <h2 class="warnings-title"><i class="fas fa-triangle-exclamation"></i>Tenuous Tips</h2>
                 <div id="tenuousTipsGrid" class="warnings-grid">
+                    <div class="warning-card">No adventurers in your party yet. Import some brave souls!</div>
+                </div>
+            </div>
+
+            <!-- Advanced Tips Section -->
+            <div id="advancedTipsContainer" class="warnings-container">
+                <h2 class="warnings-title"><i class="fas fa-hat-wizard"></i>Advanced Tips</h2>
+                <div id="advancedTipsGrid" class="warnings-grid">
                     <div class="warning-card">No adventurers in your party yet. Import some brave souls!</div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 // Global variables
 let characters = [];
 let warnings = [];
+let advancedTips = []; // New array to store advanced tips
 let healingAbilities = []; // New variable to store healing abilities
 let tenuousTips = []; // New array to store tenuous tips
 
@@ -155,6 +156,30 @@ async function loadTenuousTips() {
     }
 }
 
+// Function to load advanced tips from YAML files
+async function loadAdvancedTips() {
+    try {
+        const tipFiles = [
+            'advanced-tips/rock-paper-scissors.yaml',
+            'advanced-tips/spiritual-pressure.yaml',
+            'advanced-tips/started-blasting.yaml',
+            'advanced-tips/too-poor.yaml',
+            'advanced-tips/training-arc.yaml',
+            'advanced-tips/see-no-evil.yaml',
+            'advanced-tips/shadow-plane-sucks.yaml',
+            'advanced-tips/swing-and-a-miss.yaml',
+            'advanced-tips/reaction-time.yaml',
+            'advanced-tips/stitch-flesh.yaml',
+            'advanced-tips/trained-no-mod.yaml',
+            'advanced-tips/gather-knowledge.yaml',
+        ];
+
+        await loadYamlFiles(tipFiles, advancedTips, "advanced tips");
+    } catch (error) {
+        console.error('Error loading advanced tips:', error);
+    }
+}
+
 // Function to process the JSON data from input
 function processJsonData(jsonString) {
     try {
@@ -299,6 +324,11 @@ function extractField(data, fieldConfig, extractors) {
         // SPECIAL CASE: Handle defense calculations using the dedicated JS function
         if (formula === "calculateAllDefenses") {
             return extractDefenseValues(data);
+        }
+
+        // SPECIAL CASE: Speed uses characterAttributes module
+        if (formula === "calculateSpeed") {
+            return characterAttributes.calculateSpeed(data);
         }
 
         if (type === 'object' && fieldConfig.fields) {
@@ -1351,7 +1381,7 @@ function addWarning(container, title, description, isSuccess) {
 
     const descElem = document.createElement('div');
     descElem.className = 'warning-description';
-    descElem.textContent = description;
+    renderStructuredMessage(descElem, description);
 
     content.appendChild(titleElem);
     content.appendChild(descElem);
@@ -1360,6 +1390,64 @@ function addWarning(container, title, description, isSuccess) {
     card.appendChild(content);
 
     container.appendChild(card);
+}
+
+// Turn a free-form message into structured DOM:
+//   "||" — block boundary (new line/group)
+//   ". " before uppercase — sentence boundary (new line)
+//   " | " — sub-item separator inside a line (becomes <ul><li>)
+//   "Label: rest" / "Label — rest" — bold the label prefix
+function renderStructuredMessage(parent, text) {
+    if (!text) return;
+    const blocks = String(text).split(/\s*\|\|\s*/);
+    for (const block of blocks) {
+        // Split on sentence boundary: ". " followed by uppercase letter or quote
+        const sentences = block.split(/\.\s+(?=[A-Z"“‘])/);
+        for (let raw of sentences) {
+            raw = raw.trim();
+            if (!raw) continue;
+            // Restore trailing period if it was the natural sentence end and not last
+            if (!/[.!?…]$/.test(raw)) raw += '.';
+
+            // Sub-items inside line, split on " | " (single pipe)
+            const parts = raw.split(/\s+\|\s+/);
+            if (parts.length > 1) {
+                // First part may carry an intro label; render it as a line, then a bullet list
+                const lead = parts.shift().trim();
+                if (lead) appendLine(parent, lead);
+                const ul = document.createElement('ul');
+                ul.className = 'warning-items';
+                for (const part of parts) {
+                    const li = document.createElement('li');
+                    appendLabeled(li, part.trim());
+                    ul.appendChild(li);
+                }
+                parent.appendChild(ul);
+            } else {
+                appendLine(parent, raw);
+            }
+        }
+    }
+}
+
+function appendLine(parent, text) {
+    const line = document.createElement('div');
+    line.className = 'warning-line';
+    appendLabeled(line, text);
+    parent.appendChild(line);
+}
+
+// If text starts with "Label: rest" or "Label — rest", bold the label.
+function appendLabeled(node, text) {
+    const match = text.match(/^([^:—\n]{1,40})([:—])\s+(.+)$/);
+    if (match) {
+        const strong = document.createElement('strong');
+        strong.textContent = match[1].trim();
+        node.appendChild(strong);
+        node.appendChild(document.createTextNode(`${match[2]} ${match[3]}`));
+    } else {
+        node.textContent = text;
+    }
 }
 
 // Event Listener for Import Button (File)
@@ -1442,7 +1530,16 @@ function loadCharactersFromCache() {
     try {
         const cachedCharacters = localStorage.getItem('pf2e-characters');
         if (cachedCharacters) {
-            characters = JSON.parse(cachedCharacters);
+            const parsed = JSON.parse(cachedCharacters);
+            // Re-preprocess so cached chars pick up current extractor logic
+            characters = parsed.map(c => {
+                try {
+                    return preprocessCharacterData(c);
+                } catch (e) {
+                    console.error('Re-preprocess failed for cached char, keeping as-is:', e);
+                    return c;
+                }
+            });
             console.log('Loaded characters from cache:', characters.length);
         }
     } catch (error) {
@@ -1504,10 +1601,11 @@ async function init() {
         // Initialize the table with the loaded structure
         initializeTableStructure(tableStructure);
 
-        // Load warnings, healing abilities, and tenuous tips
+        // Load warnings, healing abilities, tenuous tips, and advanced tips
         await Promise.all([
             loadWarnings(),
-            loadTenuousTips()
+            loadTenuousTips(),
+            loadAdvancedTips()
         ]);
 
         // Load characters from cache
@@ -1606,6 +1704,68 @@ async function importPartyFromClipboard() {
 // Replace the file-based party export/import event listeners with these in your initialization code
 document.getElementById('exportPartyClipboardButton').addEventListener('click', exportPartyToClipboard);
 document.getElementById('importPartyClipboardButton').addEventListener('click', importPartyFromClipboard);
+
+function applyPartyData(partyData) {
+    if (!partyData || partyData.format !== 'pf2e-character-comparison-party') {
+        showStatusMessage('Invalid party data format', true);
+        return false;
+    }
+    if (!Array.isArray(partyData.characters) || partyData.characters.length === 0) {
+        showStatusMessage('No characters found in the party data', true);
+        return false;
+    }
+    characters = partyData.characters.map(c => {
+        try { return preprocessCharacterData(c); } catch (e) { return c; }
+    });
+    renderCharacters();
+    saveCharactersToCache(characters);
+    showStatusMessage(`Imported party with ${characters.length} characters!`);
+    return true;
+}
+
+function exportPartyToFile() {
+    if (characters.length === 0) {
+        showStatusMessage('No characters to export!', true);
+        return;
+    }
+    const partyExport = {
+        format: 'pf2e-character-comparison-party',
+        version: '1.0',
+        exportDate: new Date().toISOString(),
+        characters: characters
+    };
+    const blob = new Blob([JSON.stringify(partyExport, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    a.href = url;
+    a.download = `pf2e-party-${stamp}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    showStatusMessage(`Party saved to ${a.download}`);
+}
+
+function restorePartyFromFile(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+        try {
+            applyPartyData(JSON.parse(e.target.result));
+        } catch (err) {
+            console.error('Error parsing party file:', err);
+            showStatusMessage('Could not parse party file. Make sure it is a valid Save Party file.', true);
+        }
+        event.target.value = ''; // allow re-selecting the same file later
+    };
+    reader.onerror = () => showStatusMessage('Error reading file.', true);
+    reader.readAsText(file);
+}
+
+document.getElementById('savePartyFileButton').addEventListener('click', exportPartyToFile);
+document.getElementById('restorePartyFileInput').addEventListener('change', restorePartyFromFile);
 
 // Extract value from character based on path specified in YAML
 function extractValueByPath(object, path) {
@@ -1966,6 +2126,22 @@ function createExtractorFunction(formulaStr) {
             };
         }
 
+        // For function-call formulas like "getProficiencyLevel(value)", destructure params by arg name
+        if (typeof formulaStr === 'string') {
+            const callMatch = formulaStr.match(/^(\w+)\s*\(\s*([^)]*)\)\s*$/);
+            if (callMatch) {
+                const argNames = callMatch[2].split(',').map(s => s.trim()).filter(Boolean);
+                return (params) => {
+                    const args = argNames.map(name => params && params[name] !== undefined ? params[name] : params);
+                    // Resolve func from global scope (window or globalThis)
+                    const func = (typeof window !== 'undefined' ? window[callMatch[1]] : globalThis[callMatch[1]]);
+                    if (typeof func === 'function') return func(...args);
+                    // Fallback: evaluate via Function as before
+                    return new Function(...argNames, `return ${formulaStr}`)(...args);
+                };
+            }
+        }
+
         // For simple math formulas, create a function that evaluates the formula
         return new Function('value', `return ${formulaStr}`);
     } catch (error) {
@@ -2031,6 +2207,11 @@ function extractField(data, fieldConfig, extractors) {
         // SPECIAL CASE: Handle defense calculations using the dedicated JS function
         if (formula === "calculateAllDefenses") {
             return extractDefenseValues(data);
+        }
+
+        // SPECIAL CASE: Speed uses characterAttributes module
+        if (formula === "calculateSpeed") {
+            return characterAttributes.calculateSpeed(data);
         }
 
         if (type === 'object' && fieldConfig.fields) {
@@ -2099,7 +2280,17 @@ function legacyPreprocessCharacterData(data) {
 
 // Function to update tenuous tips display
 function updateTenuousTips() {
-    const tipsGrid = document.getElementById('tenuousTipsGrid');
+    renderTipList(tenuousTips, 'tenuousTipsGrid');
+    updateAdvancedTips();
+}
+
+function updateAdvancedTips() {
+    renderTipList(advancedTips, 'advancedTipsGrid');
+}
+
+function renderTipList(tipList, gridId) {
+    const tipsGrid = document.getElementById(gridId);
+    if (!tipsGrid) return;
     tipsGrid.innerHTML = ''; // Clear existing tips
 
     // Don't show tips if no characters
@@ -2109,7 +2300,7 @@ function updateTenuousTips() {
     }
 
     // Process each tip
-    tenuousTips.forEach(tip => {
+    tipList.forEach(tip => {
         try {
             // Evaluate the check function
             let isSuccess = false;
@@ -2253,9 +2444,9 @@ function renderSection(section, data) {
 async function loadYamlFiles(fileList, targetArray, description) {
     targetArray.length = 0; // Clear array
 
-    // Load each file
+    // Load each file (bust browser cache so updates land without hard-refresh)
     for (const file of fileList) {
-        const response = await fetch(file);
+        const response = await fetch(file, { cache: 'no-store' });
         if (response.ok) {
             const yamlText = await response.text();
             const config = jsyaml.load(yamlText);

--- a/style.css
+++ b/style.css
@@ -201,30 +201,7 @@ h1 {
     background-color: var(--warning-color);
 }
 
-/* File Input Styling */
-.file-input-label {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 20px;
-    border-radius: 5px;
-    background-color: var(--accent-secondary);
-    color: var(--parchment-color);
-    cursor: pointer;
-    font-family: 'Cinzel', serif;
-    font-weight: bold;
-    box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
-    text-transform: uppercase;
-    transition: all 0.3s ease;
-    border: 1px solid rgba(0, 0, 0, 0.2);
-}
-
-.file-input-label:hover {
-    background-color: var(--accent-tertiary);
-    transform: translateY(-2px);
-    box-shadow: 0 5px 8px rgba(0, 0, 0, 0.3);
-}
-
+/* File-input label is styled via .pf-button — only the hidden input needs CSS here */
 input[type="file"] {
     display: none;
 }
@@ -577,6 +554,31 @@ td .highest {
     font-size: 0.95rem;
 }
 
+.warning-line {
+    margin-top: 4px;
+    line-height: 1.4;
+}
+
+.warning-line:first-child {
+    margin-top: 0;
+}
+
+.warning-description strong {
+    color: var(--accent-primary);
+    margin-right: 4px;
+}
+
+.warning-items {
+    list-style: disc;
+    padding-left: 22px;
+    margin: 4px 0;
+}
+
+.warning-items li {
+    margin-top: 2px;
+    line-height: 1.35;
+}
+
 /* Footer */
 footer {
     text-align: center;
@@ -618,8 +620,7 @@ footer a:hover {
         flex-direction: column;
     }
 
-    .pf-button,
-    .file-input-label {
+    .pf-button {
         width: 100%;
     }
 }

--- a/tenuous-tips/thievery-tools.yaml
+++ b/tenuous-tips/thievery-tools.yaml
@@ -1,64 +1,36 @@
 title: Maybe Try Knocking?
-description: Checks if characters with Thievery proficiency have thieves' tools
+description: Trained-in-Thievery characters need thieves' tools
 checkFunction: |
   function() {
-    // If there are no characters, don't show a warning
     if (characters.length === 0) return true;
-    
-    // Track if any character has thievery proficiency
-    let anyCharacterWithThievery = false;
-    let thieveryCharacterHasTools = false;
-    
-    for (const character of characters) {
-      // Check for thievery proficiency explicitly to ensure it's >= 2 (Trained in PF2e)
-      let hasThievery = false;
-      
-      // Check build.proficiencies path
-      if (character.proficiencies && character.proficiencies.thievery >= 2) {
-        hasThievery = true;
-      }
-      // Check extracted.skillProficiencies path
-      else if (character.extracted && 
-               character.extracted.skillProficiencies && 
-               character.extracted.skillProficiencies.thievery && 
-               character.extracted.skillProficiencies.thievery !== 'U') {
-        hasThievery = true;
-      }
-      // Check extracted.skills path (numeric value)
-      else if (character.extracted && 
-               character.extracted.skills && 
-               character.extracted.skills.thievery >= 2) {
-        hasThievery = true;
-      }
-      
-      if (hasThievery) {
-        anyCharacterWithThievery = true;
-        
-        // Check equipment for thieves' tools
-        if (character.equipment) {
-          for (const item of character.equipment) {
-            const itemName = String(item[0] || "").toLowerCase();
-            if (itemName.includes("thieve") && itemName.includes("tool")) {
-              thieveryCharacterHasTools = true;
-              break;
-            }
-          }
-        }
-        
-        // Also check in build.equipment if available
-        if (!thieveryCharacterHasTools && character.build && character.build.equipment) {
-          for (const item of character.build.equipment) {
-            const itemName = String(item[0] || "").toLowerCase();
-            if (itemName.includes("thieve") && itemName.includes("tool")) {
-              thieveryCharacterHasTools = true;
-              break;
-            }
-          }
+
+    const hasThievery = (c) => {
+      if (c.proficiencies && c.proficiencies.thievery >= 2) return true;
+      const prof = c.extracted?.skillProficiencies?.thievery;
+      if (prof && prof !== 'U') return true;
+      const direct = c.build?.proficiencies?.thievery;
+      if (typeof direct === 'number' && direct >= 2) return true;
+      return false;
+    };
+
+    const hasTools = (c) => {
+      const sources = [c.equipment, c.build?.equipment].filter(Boolean);
+      for (const eq of sources) {
+        for (const item of eq) {
+          const itemName = String(Array.isArray(item) ? item[0] : (item?.name || item) || '').toLowerCase();
+          if (itemName.includes('thieve') && itemName.includes('tool')) return true;
         }
       }
-    }
-    
-    return thieveryCharacterHasTools;
+      return false;
+    };
+
+    const trainedNoTools = characters
+      .filter(hasThievery)
+      .filter(c => !hasTools(c))
+      .map(c => c.build?.name || 'Unknown');
+
+    window.thievesToolsMissing = trainedNoTools;
+    return trainedNoTools.length === 0;
   }
-successMessage: Your party is well-equipped for locks and traps.
-failureMessage: You have no characters with Thievery, or a character with Thievery proficiency needs thieves' tools! Without them, they have a -2 penalty on Pick Lock actions and some locks can't be attempted at all.
+successMessage: Thievery-trained characters have thieves' tools. Locks and traps handled.
+failureMessage: "Thievery without thieves' tools: {{thievesToolsMissing.join(', ')}}. -2 on Pick Lock and some locks won't open at all — buy the kit."


### PR DESCRIPTION
Features:
- New Advanced Tips section with 12 party-coverage checks: damage type spread (rock-paper-scissors, started-blasting, spiritual-pressure), weapon materials (too-poor), magic weapon tier (training-arc), tactical options (see-no-evil, shadow-plane-sucks, swing-and-a-miss, reaction-time, stitch-flesh), skill polish (trained-no-mod, gather-knowledge).
- Save Party to File / Restore Party from File buttons backed by Blob download + FileReader, sharing format/validation with Share Party.
- Structured message renderer for all warning/tip cards: splits on ||, sentence boundaries, and " | "; bolds Label: prefixes; bullet lists sub-items.

Bug fixes:
- createExtractorFunction: function-call formulas like getProficiencyLevel(value) now destructure params by arg name, so proficiency badges and skill-coverage no longer collapse to U.
- Special-case calculateSpeed extractor (was warning "Unknown formula").
- loadCharactersFromCache re-runs preprocessing so cached chars pick up current extractor logic without a Clear All.
- Cache: 'no-store' on YAML fetches so authored changes land on a normal refresh.

Cleanup:
- Deduped .pf-button / .file-input-label styling; labels now use .pf-button with .secondary modifier. Single source of truth.
- Rewrote thievery-tools to focus on tools (skill-coverage already flags missing training); deduped Needle Darts carriers.